### PR TITLE
Revert "audio: Disable voice log by default"

### DIFF
--- a/audio/voice.c
+++ b/audio/voice.c
@@ -15,7 +15,7 @@
  */
 
 #define LOG_TAG "audio_hw_voice"
-/*#define LOG_NDEBUG 0*/
+#define LOG_NDEBUG 0
 /*#define VERY_VERY_VERBOSE_LOGGING*/
 #ifdef VERY_VERY_VERBOSE_LOGGING
 #define ALOGVV ALOGV


### PR DESCRIPTION
This was intentionally left enabled and does not spam anyways,
but allows users to extract helpful information without
recompiling.

This reverts commit e06577dc818d047dae1caec397fa7316762e3fb7.

Change-Id: I604ee674a1db466b3d3e364cb95f5688edd4947c