### PR TITLE
libril: use responseInts for LAST_CALL_FAIL_CAUSE on Exynos4

### DIFF
--- a/ril/libril/ril_commands.h
+++ b/ril/libril/ril_commands.h
@@ -32,7 +32,15 @@
     {RIL_REQUEST_SWITCH_WAITING_OR_HOLDING_AND_ACTIVE, dispatchVoid, responseVoid},
     {RIL_REQUEST_CONFERENCE, dispatchVoid, responseVoid},
     {RIL_REQUEST_UDUB, dispatchVoid, responseVoid},
+#ifndef EXYNOS4_ENHANCEMENTS
     {RIL_REQUEST_LAST_CALL_FAIL_CAUSE, dispatchVoid, responseFailCause},
+#else
+    /*
+     * Exynos4 devices send an extra int for LAST_CALL_FAIL_CAUSE
+     * which causes responseFailCause to think it's a string and crash.
+     */
+    {RIL_REQUEST_LAST_CALL_FAIL_CAUSE, dispatchVoid, responseInts},
+#endif
     {RIL_REQUEST_SIGNAL_STRENGTH, dispatchVoid, responseRilSignalStrength},
     {RIL_REQUEST_VOICE_REGISTRATION_STATE, dispatchVoid, responseStrings},
     {RIL_REQUEST_DATA_REGISTRATION_STATE, dispatchVoid, responseStrings},


### PR DESCRIPTION
Exynos4 devices send two ints as a response to this request,
causing responseFailCause to think the result is a LastCallFailCause struct,
which it then tries to treat as a Java UTF-8 encoded string, causing a
crash.

Work around this by forcing responseInts (the original behaviour)
on Exynos4 devices.

Change-Id: Ied14948db3049066ffc760b6d3df09b4cefa2df0